### PR TITLE
🐛 fix: resolve Google Maps API console errors

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -1155,11 +1155,15 @@ class Map
         $this->output_html = "";
 
         if ($this->maps_loaded == 0) {
-            if ($this->apiKey != "") {
-                $apiLocation = 'https://maps.googleapis.com/maps/api/js?v=3&key='.$this->apiKey.'&';
-            } else {
-                $apiLocation = 'https://maps.google.com/maps/api/js?v=3&';
+            if ($this->apiKey == "") {
+                throw new \RuntimeException(
+                    'A Google Maps API key is required. Set it via config("services.google.maps.api-key") '
+                    . 'or pass "apiKey" when initializing the map. '
+                    . 'Get a key at https://console.cloud.google.com/apis/credentials'
+                );
             }
+
+            $apiLocation = 'https://maps.googleapis.com/maps/api/js?v=weekly&key='.$this->apiKey.'&';
             if ($this->region != "" && strlen($this->region) == 2) {
                 $apiLocation .= '&region='.strtoupper($this->region);
             }
@@ -1572,13 +1576,13 @@ class Map
         if ($this->center == "auto") { // if wanting to center on the users location
             $this->output_js_contents .= '
 				// Try W3C Geolocation (Preferred)
-				if(navigator.geolocation) {
+				if(window.isSecureContext && navigator.geolocation) {
 					navigator.geolocation.getCurrentPosition(function(position) {
 						'.$this->map_name.'.setCenter(new google.maps.LatLng(position.coords.latitude,position.coords.longitude));
 					}, function() { alert("Unable to get your current position. Please try again. Geolocation service failed."); });
-				// Browser doesn\'t support Geolocation
+				// Browser doesn\'t support Geolocation or not on HTTPS
 				}else{
-					alert(\'Your browser does not support geolocation.\');
+					console.warn(\'Geolocation requires a secure origin (HTTPS). See https://goo.gl/rStTGz\');
 				}
 			';
         }
@@ -2036,42 +2040,42 @@ class Map
                 // Both start and finish are at the users current location
                 $this->output_js_contents .= '
 				// Try W3C Geolocation (Preferred)
-				if(navigator.geolocation) {
+				if(window.isSecureContext && navigator.geolocation) {
 					navigator.geolocation.getCurrentPosition(function(position) {
 						start = position.coords.latitude+","+position.coords.longitude;
 						calcRoute(start, start);
 					}, function() { alert("Unable to get your current position. Please try again. Geolocation service failed."); });
-				// Browser doesn\'t support Geolocation
+				// Browser doesn\'t support Geolocation or not on HTTPS
 				}else{
-					alert(\'Your browser does not support geolocation.\');
+					console.warn(\'Geolocation requires a secure origin (HTTPS). See https://goo.gl/rStTGz\');
 				}
 				';
             } elseif ($this->directionsStart == "auto") {
                 // The start point should be at the users current location
                 $this->output_js_contents .= '
 				// Try W3C Geolocation (Preferred)
-				if(navigator.geolocation) {
+				if(window.isSecureContext && navigator.geolocation) {
 					navigator.geolocation.getCurrentPosition(function(position) {
 						start = position.coords.latitude+","+position.coords.longitude;
 						calcRoute(start, \''.$this->directionsEnd.'\');
 					}, function() { alert("Unable to get your current position. Please try again. Geolocation service failed."); });
-				// Browser doesn\'t support Geolocation
+				// Browser doesn\'t support Geolocation or not on HTTPS
 				}else{
-					alert(\'Your browser does not support geolocation.\');
+					console.warn(\'Geolocation requires a secure origin (HTTPS). See https://goo.gl/rStTGz\');
 				}
 				';
             } elseif ($this->directionsEnd == "auto") {
                 // The end point should be at the users current location
                 $this->output_js_contents .= '
 				// Try W3C Geolocation (Preferred)
-				if(navigator.geolocation) {
+				if(window.isSecureContext && navigator.geolocation) {
 					navigator.geolocation.getCurrentPosition(function(position) {
 						end = position.coords.latitude+","+position.coords.longitude;
 						calcRoute(\''.$this->directionsStart.'\', end);
 					}, function() { alert("Unable to get your current position. Please try again. Geolocation service failed."); });
-				// Browser doesn\'t support Geolocation
+				// Browser doesn\'t support Geolocation or not on HTTPS
 				}else{
-					alert(\'Your browser does not support geolocation.\');
+					console.warn(\'Geolocation requires a secure origin (HTTPS). See https://goo.gl/rStTGz\');
 				}
 				';
             } else {

--- a/tests/Unit/MapTest.php
+++ b/tests/Unit/MapTest.php
@@ -58,4 +58,68 @@ class MapTest extends UnitTestCase
         $this->assertInstanceOf(Map::class, $map);
         $this->assertSame('', $map->apiKey);
     }
+
+    public function test_create_map_throws_exception_without_api_key(): void
+    {
+        $map = new Map();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('A Google Maps API key is required');
+
+        $map->create_map();
+    }
+
+    public function test_create_map_uses_weekly_api_version(): void
+    {
+        $map = new Map(['apiKey' => 'test-key']);
+        $output = $map->create_map();
+
+        $this->assertStringContainsString('v=weekly', $output['js']);
+        $this->assertStringNotContainsString('v=3', $output['js']);
+    }
+
+    public function test_create_map_uses_correct_api_domain(): void
+    {
+        $map = new Map(['apiKey' => 'test-key']);
+        $output = $map->create_map();
+
+        $this->assertStringContainsString(
+            'https://maps.googleapis.com/maps/api/js',
+            $output['js']
+        );
+    }
+
+    public function test_create_map_includes_api_key_in_script(): void
+    {
+        $map = new Map(['apiKey' => 'my-test-key-123']);
+        $output = $map->create_map();
+
+        $this->assertStringContainsString('key=my-test-key-123', $output['js']);
+    }
+
+    public function test_geolocation_checks_secure_context(): void
+    {
+        $map = new Map(['apiKey' => 'test-key']);
+        $map->initialize(['center' => 'auto']);
+        $output = $map->create_map();
+
+        $this->assertStringContainsString('window.isSecureContext', $output['js']);
+        $this->assertStringContainsString(
+            'Geolocation requires a secure origin',
+            $output['js']
+        );
+    }
+
+    public function test_directions_geolocation_checks_secure_context(): void
+    {
+        $map = new Map(['apiKey' => 'test-key']);
+        $map->initialize([
+            'directions' => true,
+            'directionsStart' => 'auto',
+            'directionsEnd' => 'some destination',
+        ]);
+        $output = $map->create_map();
+
+        $this->assertStringContainsString('window.isSecureContext', $output['js']);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes console errors caused by missing API key validation, deprecated API version, and insecure geolocation calls.

## Changes
- Require API key in `create_map()` — throws `RuntimeException` with setup instructions when missing
- Update Google Maps JS API from deprecated `v=3` to `v=weekly` (current recommended version)
- Add `isSecureContext` check before `getCurrentPosition()` calls to prevent deprecation warnings on HTTP
- Replace intrusive `alert()` calls with `console.warn()` for geolocation fallback on insecure origins

## Acceptance Criteria
- [x] The reported error/bug no longer occurs under the described conditions
- [x] Existing tests continue to pass with no regressions
- [x] A regression test is added to prevent recurrence

## Test Coverage
- `test_create_map_throws_exception_without_api_key` — verifies RuntimeException when no key
- `test_create_map_uses_weekly_api_version` — verifies v=weekly, no v=3
- `test_create_map_uses_correct_api_domain` — verifies googleapis.com domain
- `test_create_map_includes_api_key_in_script` — verifies key in output
- `test_geolocation_checks_secure_context` — verifies isSecureContext guard
- `test_directions_geolocation_checks_secure_context` — verifies isSecureContext in directions

Fixes #5
